### PR TITLE
Update runtime. To specify PHP, now use php55.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -5,7 +5,7 @@
 api_version: 1
 threadsafe: yes
 
-runtime: php
+runtime: php55
 application: replace-with-your-project-id
 version: 1
 


### PR DESCRIPTION
"After 16th April, 2015 we will begin automatically migrating all applications to the php55 runtime." - The PHP for App Engine Team
https://groups.google.com/forum/#!topic/google-appengine/9PMjrTxVy4w
https://cloud.google.com/appengine/docs/php/config/appconfig#runtime